### PR TITLE
Add windows support

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -407,7 +407,7 @@ func (c *Cmd) run() {
 	// Set process group ID so the cmd and all its children become a new
 	// process group. This allows Stop to SIGTERM the cmd's process group
 	// without killing this process (i.e. this code here).
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	setSysProcAttr()
 
 	// Write stdout and stderr to buffers that are safe to read while writing
 	// and don't cause a race condition.

--- a/cmd.go
+++ b/cmd.go
@@ -407,7 +407,7 @@ func (c *Cmd) run() {
 	// Set process group ID so the cmd and all its children become a new
 	// process group. This allows Stop to SIGTERM the cmd's process group
 	// without killing this process (i.e. this code here).
-	setSysProcAttr()
+	cmd.SysProcAttr = setSysProcAttr()
 
 	// Write stdout and stderr to buffers that are safe to read while writing
 	// and don't cause a race condition.

--- a/cmd_notwin.go
+++ b/cmd_notwin.go
@@ -1,0 +1,9 @@
+// +build !windows
+
+package overseer
+
+import "syscall"
+
+func setSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setpgid: true}
+}

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -165,10 +165,10 @@ func TestCmdStop(t *testing.T) {
 
 	expectStatus := cmd.Status{
 		Cmd:     "./testdata/count-and-sleep",
-		PID:     gotStatus.PID,                    // nondeterministic
-		Exit:    -1,                               // signaled by Stop
-		Error:   errors.New("signal: terminated"), // signaled by Stop
-		Runtime: gotStatus.Runtime,                // nondeterministic
+		PID:     gotStatus.PID,                // nondeterministic
+		Exit:    -1,                           // signaled by Stop
+		Error:   errors.New("signal: killed"), // signaled by Stop
+		Runtime: gotStatus.Runtime,            // nondeterministic
 		Stdout:  []string{"1"},
 		Stderr:  []string{},
 	}

--- a/cmd_windows.go
+++ b/cmd_windows.go
@@ -1,0 +1,9 @@
+// +build windows
+
+package overseer
+
+import "syscall"
+
+func setSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{}
+}


### PR DESCRIPTION
This should add basic Windows support. I haven't tested it thoroughly but the example built and ran on Windows:

![](https://cl.ly/d994b0fa634b/Screen%20Shot%202019-10-12%20at%2012.47.16%20PM.png)

(note it seems a permission issue caused some problems on the run but it seems the build binary works and does what you would expect)

What I did:

- I changed to using `os.Kill()` which is platform independent
- I added a `cmd_*.go` file for each OS that sets the `SysProcAttr` since `Setgid` is invalid on Windows

Those two changes seem to make it work and build properly. Had to make one change to the test based on the new outgoing message change (I guess `os.Kill` sends `killed` instead of `terminated`). 

Tests passed on my Mac, didn't run them on Windows. 