### PR TITLE
fix: prevent go routine for STDOUT/STDERR from looping forever.

### DIFF
--- a/examples/simple-overseer/main.go
+++ b/examples/simple-overseer/main.go
@@ -45,6 +45,7 @@ func main() {
 			case <-ticker.C:
 				if !ovr.IsRunning() {
 					fmt.Println("Closing Stdout and Stderr loop")
+					return //terminate go routine
 				}
 			}
 		}
@@ -54,6 +55,6 @@ func main() {
 	ovr.SuperviseAll()
 
 	// Even after the command is finished, you can still access detailed info
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(300 * time.Millisecond)
 	fmt.Println(ovr.Status(id1))
 }


### PR DESCRIPTION
Terminating the go func when ticker signal is caught and !ovr.IsRunning
Prolonged Sleep to 300ms to test/show the effect.