### PR TITLE
Fix CPU usage bug while supervising. Remove default case so process log change goroutine can exit.

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -490,12 +490,13 @@ func (ovr *Overseer) Supervise(id string) int {
 							logChan <- &LogMsg{STDERR, line}
 						}
 					}
-				default:
-					if !ovr.IsRunning() || c.IsFinalState() {
-						// log.Info("Close STDOUT and STDERR loop:", Attrs{"id": id})
-						return
-					}
 				}
+				
+				if !ovr.IsRunning() || c.IsFinalState() {
+					// log.Info("Close STDOUT and STDERR loop:", Attrs{"id": id})
+					return
+				}
+				
 				time.Sleep(timeUnit)
 			}
 		}(c)

--- a/manager.go
+++ b/manager.go
@@ -495,8 +495,8 @@ func (ovr *Overseer) Supervise(id string) int {
 						// log.Info("Close STDOUT and STDERR loop:", Attrs{"id": id})
 						return
 					}
-					time.Sleep(timeUnit)
 				}
+				time.Sleep(timeUnit)
 			}
 		}(c)
 

--- a/manager.go
+++ b/manager.go
@@ -472,32 +472,27 @@ func (ovr *Overseer) Supervise(id string) int {
 		// Async start
 		c.Start()
 
-		// Process all log changes
+		// Process Stdout log changes
 		go func(c *Cmd) {
-			for {
-				select {
-				case line := <-c.Stdout:
-					if len(line) > 0 {
-						log.Info(line)
-						for _, logChan := range ovr.loggers {
-							logChan <- &LogMsg{STDOUT, line}
-						}
-					}
-				case line := <-c.Stderr:
-					if len(line) > 0 {
-						log.Error(line)
-						for _, logChan := range ovr.loggers {
-							logChan <- &LogMsg{STDERR, line}
-						}
-					}
+			for line := range c.Stdout {
+				log.Info(line)
+				ovr.access.RLock()
+				for _, logChan := range ovr.loggers {
+					logChan <- &LogMsg{STDOUT, line}
 				}
-				
-				if !ovr.IsRunning() || c.IsFinalState() {
-					// log.Info("Close STDOUT and STDERR loop:", Attrs{"id": id})
-					return
+				ovr.access.RUnlock()
+			}
+		}(c)
+
+		// Process Stderr log changes
+		go func(c *Cmd) {
+			for line := range c.Stderr {
+				log.Info(line)
+				ovr.access.RLock()
+				for _, logChan := range ovr.loggers {
+					logChan <- &LogMsg{STDERR, line}
 				}
-				
-				time.Sleep(timeUnit)
+				ovr.access.RUnlock()
 			}
 		}(c)
 

--- a/manager_test.go
+++ b/manager_test.go
@@ -312,7 +312,43 @@ func TestOverseerSleep(t *testing.T) {
 	assert.True(ovr.Remove(id))
 }
 
-func TestOverseerWatchLogs(t *testing.T) {
+func TestOverseerWatchLogsSupervise(t *testing.T) {
+	assert := assert.New(t)
+	ovr := cmd.NewOverseer()
+
+	opts := cmd.Options{Buffered: false, Streaming: true}
+	ovr.Add("echo", "echo", []string{"ECHO!"}, opts)
+	ovr.Add("ping", "ping", []string{"127.0.0.1", "-c", "1"}, opts)
+
+	assert.Equal(2, len(ovr.ListAll()))
+
+	lg := make(chan *cmd.LogMsg)
+	ovr.WatchLogs(lg)
+
+	messages := ""
+	lock := &sync.Mutex{}
+	go func() {
+		for logMsg := range lg {
+			lock.Lock()
+			assert.NotEqual(2, logMsg.Type) // Will this work on all platforms?
+			messages += logMsg.Text
+			lock.Unlock()
+		}
+	}()
+
+	ovr.Supervise("echo")
+	ovr.Supervise("ping")
+	// for some stupid reason, this wait is needed for CI
+	time.Sleep(timeUnit)
+
+	lock.Lock()
+	assert.True(strings.ContainsAny(messages, "ECHO!"))
+	assert.True(strings.ContainsAny(messages, "(127.0.0.1)"))
+	assert.True(strings.ContainsAny(messages, "ping statistics"))
+	lock.Unlock()
+}
+
+func TestOverseerWatchLogsSuperviseAll(t *testing.T) {
 	assert := assert.New(t)
 	ovr := cmd.NewOverseer()
 


### PR DESCRIPTION
I noticed that overseer was using a large amount of CPU time when supervising. I tracked this down to the goroutine that processes log changes. I believe the sleep should be outside the default case so this goroutine doesn't spin as fast as possible. Moving the sleep fixed the issue and I no longer see overseer processes use 100% of the core they run on.